### PR TITLE
remove engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,5 @@
   },
   "scripts": {
     "test": "grunt test"
-  },
-  "engines": {
-    "node": "~0.x.x"
   }
 }


### PR DESCRIPTION
this has been causing this warning in npm lately:

```
npm WARN engine cuid@1.2.4: wanted: {"node":"~0.x.x"} (current: {"node":"2.0.0","npm":"2.9.0"})
```

I don't think its needed, correct me if I'm wrong!