### PR TITLE
Dropping 0.8 "support" for cuid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 0.8
+  - 0.10


### PR DESCRIPTION
Some of the dependencies of cuid's dependencies use the `^` syntax in their package.json for dependencies (e.g. glob@'^5.0.6'), which is unsupported in the npm version shipped with node 0.8. Updating the Travis config to use node 0.10 resolves this.

Closes #28