### PR TITLE
Fix for broken applitude reference

### DIFF
--- a/dist/browser-cuid.js
+++ b/dist/browser-cuid.js
@@ -99,7 +99,7 @@
   };
 
   // don't change anything from here down.
-  if (app.register) {
+  if (app && app.register) {
     app.register(namespace, api);
   } else if (typeof module !== 'undefined') {
     module.exports = api;
@@ -107,4 +107,4 @@
     app[namespace] = api;
   }
 
-}(this.applitude || this));
+}(this));


### PR DESCRIPTION
I had an error similar to issue #41 when using cuid as a dependency of a dependency (but not a a direct dependency, strangely).  These minor changes allowed cuid to be used without error.

There may well be broader consequences of these changes, and I'm happy to provide covering tests and such if you can provide some guidance about how the dist files are generated,