### PR TITLE
moving core-js to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-loader": "5.3.0",
     "babelify": "^6.2.0",
     "browserify": "^11.0.1",
+    "core-js": "^1.1.1",
     "ecstatic": "^0.8.0",
     "eslint": "0.24.0",
     "faucet": "0.0.1",
@@ -57,7 +58,6 @@
   },
   "dependencies": {
     "browser-fingerprint": "0.0.1",
-    "core-js": "^1.1.1",
     "node-fingerprint": "^1.1.0"
   }
 }


### PR DESCRIPTION
The only place core-js is used is as a polyfill for client tests. This means that it should be a development dependency.

cuid is awesome! Keep up the great work! :+1: 