### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
   - "iojs"
   - "4"
-  - "5"
+  - "6"
+  - "7"
 install:
   - npm install
 script:


### PR DESCRIPTION
Node.js v5 and v0.10 are no longer being supported. Adds testing for Node.js v6, v7