### PR TITLE
package lib/ directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "./lib/fingerprint.js": "./lib/fingerprint.react-native.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "lib"
   ],
   "keywords": [
     "id",


### PR DESCRIPTION
Fixes packaging issue mentioned in issue #84 where we excluded the lib directory. I tested that this now works by running `npm pack` and `npm i <packed file>`, and tested everything with a quick test script.