### PR TITLE
remove files attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
   "react-native": {
     "./lib/fingerprint.js": "./lib/fingerprint.react-native.js"
   },
-  "files": [
-    "dist"
-  ],
   "keywords": [
     "id",
     "guid",


### PR DESCRIPTION
This update removes the `file` attribute from package.json, allowing all files to be published to npm. This is a bit of a holdover from the previous iteration of code and I don't think its valid any longer.

Closes #92 (once published)
Closes #85 too as this achieves the same goal (see below).

I think its probably preferable to not restrict to `lib` and `dist` per #85. Including all files means the `.ts` files get published as well as the `LICENSE` file.