### PR TITLE
update book link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,6 @@ The cuid specification should not be considered an API contract. Code that relie
 
 ### Credit
 
-Created by Eric Elliott, Author, ["Programming JavaScript Applications (O'Reilly)"](http://ericleads.com/javascript-applications/)
+Created by Eric Elliott, Author, ["Programming JavaScript Applications (O'Reilly)"](https://ericelliottjs.com/product/programming-javascript-applications-ebook/)
 
 Thanks to [Tout](http://tout.com/) for support and production testing.


### PR DESCRIPTION
Fixed the link to the book in the REAME, which pointed to some spam blog.