### PR TITLE
Fix browser client fingerprint generation

### DIFF
--- a/lib/fingerprint.browser.js
+++ b/lib/fingerprint.browser.js
@@ -1,7 +1,7 @@
 var pad = require('./pad.js');
 
 var env = typeof window === 'object' ? window : self;
-var globalCount = Object.keys(env);
+var globalCount = Object.keys(env).length;
 var mimeTypesLength = navigator.mimeTypes ? navigator.mimeTypes.length : 0;
 var clientId = pad((mimeTypesLength +
   navigator.userAgent.length).toString(36) +


### PR DESCRIPTION
I was getting cuids that looked like this: `cjdubez3g0000__,_ekryn16b`, where the fingerprint seems to be mangled.

Turns out the fingerprint being generated was the last 4 characters of the stringified keys of the window object. After a short investigation I found what I believe is a bug; here's the fix.

Since the `globalCount` variable is an array of the keys of the window or self object, stringifying it (in line 8) simply gives us a long, comma-delimited string of the keys. When we then concatenate this string to the `(mimeTypesLength + navigator.userAgent.length).toString(36)` string, then pad the result to the last 4 characters, we end up with only the last 4 characters of the stringified window keys.

It seems that the `globalCount`variable should have been the length of the key array, and not the key array itself.