### PR TITLE
Object.keys() doesn't work in IE8

### DIFF
--- a/lib/fingerprint.browser.js
+++ b/lib/fingerprint.browser.js
@@ -1,7 +1,10 @@
 var pad = require('./pad.js');
 
 var env = typeof window === 'object' ? window : self;
-var globalCount = Object.keys(env).length;
+var globalCount = 0;
+for (var prop in env) {
+  if (Object.hasOwnProperty.call(env, prop)) globalCount++;
+}
 var mimeTypesLength = navigator.mimeTypes ? navigator.mimeTypes.length : 0;
 var clientId = pad((mimeTypesLength +
   navigator.userAgent.length).toString(36) +


### PR DESCRIPTION
I know in the readme you mention explicitely that IE9+ is supported. However, we depend on this module for [bugsnag-js](https://github.com/bugsnag/bugsnag-js) and we need to support IE8 for our customers.

It turns out it's a pretty small change to support IE8, so I wondered if you wouldn't mind merging? Otherwise, I understand and we'll just have to maintain a fork 😢 