### PR TITLE
add reference to cuid for swift in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The algorithm is also easy to reproduce in other languages. You are encouraged t
 * [cuid for Java](https://github.com/graphcool/cuid-java) - [Nilan Marktanner](https://github.com/marktani)
 * [cuid for Lua](https://github.com/marcoonroad/cuid) - [Marco Aurélio](https://github.com/marcoonroad)
 * [cuid for Perl](https://github.com/zakame/Data-Cuid) - [Zak B. Elep](https://github.com/zakame)
+* [cuid for Swift](https://github.com/raphaelmansuy/cuid) - [Raphael Mansuy](https://github.com/raphaelmansuy)
 
 
 # Short URLs


### PR DESCRIPTION
I have created a swift version of cuid for IOS. I have added the reference in the file README.md

Regards
Raphael MANSUY