### PR TITLE
Fixed type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,13 +12,13 @@ declare const cuid: (() => string) & {
    *
    * @param cuid: string to check if it is a 'cuid'.
    */
-  isCuid: ((string) => boolean)
+  isCuid: ((cuid: string) => boolean)
   /**
    * Check if string is a valid 'cuid' slug.
    *
    * @param slug: string to check if it is a 'cuid' slug.
    */
-  isSlug: ((string) => boolean)
+  isSlug: ((slug: string) => boolean)
 };
 
 export = cuid;


### PR DESCRIPTION
Type definitions for `isCuid` and `isSlug` weren't defined correctly. Added a parameter name to create valid types.