### PR TITLE
getRandomValue() should not be able to return 1 exactly

### DIFF
--- a/lib/getRandomValue.browser.js
+++ b/lib/getRandomValue.browser.js
@@ -7,9 +7,9 @@ var crypto = typeof window !== 'undefined' &&
   self.crypto;
 
 if (crypto) {
-    var lim = Math.pow(2, 32) - 1;
+    var lim = Math.pow(2, 32);
     getRandomValue = function () {
-        return Math.abs(crypto.getRandomValues(new Uint32Array(1))[0] / lim);
+        return crypto.getRandomValues(new Uint32Array(1))[0] / lim;
     };
 } else {
     getRandomValue = Math.random;


### PR DESCRIPTION
Math.random returns from 0 to 1 but shouldn't be able to return 1 exactly. (And this is a crypto replacement for Math.random)